### PR TITLE
Added Toggle GUI option to toggle on/off the Menu+Status bars

### DIFF
--- a/src/gui/designer/mainWindow.ui
+++ b/src/gui/designer/mainWindow.ui
@@ -49,6 +49,8 @@
     <addaction name="separator"/>
     <addaction name="action_Open_working_folder"/>
     <addaction name="separator"/>
+    <addaction name="action_Toggle_GUI"/>
+    <addaction name="separator"/>
     <addaction name="action_Quit"/>
    </widget>
    <widget class="QMenu" name="menu_NES">
@@ -163,6 +165,11 @@
    </property>
    <property name="text">
     <string>&amp;Quit</string>
+   </property>
+  </action>
+  <action name="action_Toggle_GUI">
+   <property name="text">
+    <string>&amp;Toggle GUI</string>
    </property>
   </action>
   <action name="action_Hard_Reset">

--- a/src/gui/mainWindow.cpp
+++ b/src/gui/mainWindow.cpp
@@ -389,6 +389,7 @@ void mainWindow::shortcuts(void) {
 	// File
 	connect_shortcut(action_Open, SET_INP_SC_OPEN, SLOT(s_open()));
 	connect_shortcut(action_Quit, SET_INP_SC_QUIT, SLOT(s_quit()));
+	connect_shortcut(action_Toggle_GUI, SET_INP_SC_TOGGLE_GUI, SLOT(s_toggle_gui()));
 	// NES
 	connect_shortcut(action_Turn_Off, SET_INP_SC_TURN_OFF, SLOT(s_turn_on_off()));
 	connect_shortcut(action_Hard_Reset, SET_INP_SC_HARD_RESET, SLOT(s_make_reset()));
@@ -434,6 +435,7 @@ void mainWindow::connect_menu_signals(void) {
 	connect_action(action_Apply_Patch, SLOT(s_apply_patch()));
 	connect_action(action_Open_working_folder, SLOT(s_open_working_folder()));
 	connect_action(action_Quit, SLOT(s_quit()));
+	connect_action(action_Toggle_GUI, SLOT(s_toggle_gui()));
 	// NES
 	connect_action(action_Turn_Off, SLOT(s_turn_on_off()));
 	connect_action(action_Hard_Reset, HARD, SLOT(s_make_reset()));
@@ -875,6 +877,20 @@ void mainWindow::s_open_working_folder(void) {
 void mainWindow::s_quit(void) {
 	close();
 }
+void mainWindow::s_toggle_gui(void) {
+	if(gfx.type_of_fscreen_in_use == FULLSCR || gfx.type_of_fscreen_in_use == FULLSCR_IN_WINDOW) {
+		return;
+	}
+
+	emu_thread_pause();
+
+	menuWidget()->setVisible(!menuWidget()->isVisible());
+	statusbar->setVisible(!statusbar->isVisible());
+
+	gfx_set_screen(NO_CHANGE, NO_CHANGE, NO_CHANGE, NO_CHANGE, NO_CHANGE, TRUE, FALSE);
+
+	emu_thread_continue();
+}
 void mainWindow::s_turn_on_off(void) {
 	info.turn_off = !info.turn_off;
 
@@ -1273,6 +1289,9 @@ void mainWindow::s_shcjoy_read_timer(void) {
 					break;
 				case SET_INP_SC_QUIT:
 					action_Quit->trigger();
+					break;
+				case SET_INP_SC_TOGGLE_GUI:
+					action_Toggle_GUI->trigger();
 					break;
 				case SET_INP_SC_TURN_OFF:
 					action_Turn_Off->trigger();

--- a/src/gui/mainWindow.hpp
+++ b/src/gui/mainWindow.hpp
@@ -128,6 +128,7 @@ class mainWindow : public QMainWindow, public Ui::mainWindow {
 		void s_open_recent_roms(void);
 		void s_open_working_folder(void);
 		void s_quit(void);
+		void s_toggle_gui(void);
 		void s_turn_on_off(void);
 		void s_make_reset(void);
 		void s_insert_coin(void);

--- a/src/gui/qt.cpp
+++ b/src/gui/qt.cpp
@@ -189,7 +189,7 @@ void gui_set_video_mode(void) {
 
 	qt.mwin->setFixedSize(QSize(qt.screen->width(),
 		(qt.mwin->menubar->isHidden() ? 0 : qt.mwin->menubar->sizeHint().height()) +
-		(qt.screen->height() + 2) +
+		(qt.screen->height() + (qt.mwin->menubar->isHidden() && qt.mwin->statusbar->isHidden() ? 0 : 2)) +
 		(qt.mwin->statusbar->isHidden() ? 0 : qt.mwin->statusbar->sizeHint().height())));
 
 	qt.mwin->menubar->setFixedWidth(gfx.w[VIDEO_MODE]);

--- a/src/gui/settings.h
+++ b/src/gui/settings.h
@@ -115,6 +115,7 @@ enum pgs_element {
 enum inp_element {
 	SET_INP_SC_OPEN,
 	SET_INP_SC_QUIT,
+	SET_INP_SC_TOGGLE_GUI,
 	SET_INP_SC_TURN_OFF,
 	SET_INP_SC_HARD_RESET,
 	SET_INP_SC_SOFT_RESET,
@@ -912,6 +913,7 @@ static const _settings pgs_cfg[] = {
 static const _settings inp_cfg[] = {
 	{uL("shortcuts"), uL("open"),                        uL("Alt+O,NULL"),      NULL, NULL, {0, NULL}},
 	{uL("shortcuts"), uL("quit"),                        uL("Alt+Q,NULL"),      NULL, NULL, {0, NULL}},
+	{uL("shortcuts"), uL("toggle gui"),                  uL("F10,NULL"),        NULL, NULL, {0, NULL}},
 	{uL("shortcuts"), uL("turn off"),                    uL("Alt+R,NULL"),      NULL, NULL, {0, NULL}},
 	{uL("shortcuts"), uL("hard reset"),                  uL("F11,NULL"),        NULL, NULL, {0, NULL}},
 	{uL("shortcuts"), uL("soft reset"),                  uL("F12,NULL"),        NULL, NULL, {0, NULL}},

--- a/src/gui/wdgSettingsInput.cpp
+++ b/src/gui/wdgSettingsInput.cpp
@@ -698,6 +698,7 @@ void wdgSettingsInput::shortcuts_set(void) {
 	shortcut_update_text(mainwin->action_Load_state, SET_INP_SC_LOAD_STATE);
 	shortcut_update_text(mainwin->action_Increment_slot, SET_INP_SC_INC_SLOT);
 	shortcut_update_text(mainwin->action_Decrement_slot, SET_INP_SC_DEC_SLOT);
+	shortcut_update_text(mainwin->action_Toggle_GUI, SET_INP_SC_TOGGLE_GUI);
 }
 
 void wdgSettingsInput::s_controller_mode(int index) {


### PR DESCRIPTION
Added a "Toggle GUI" menu item in the File menu with shortcut (F10) which will toggle on and off the visibility of the Menu Bar and Status Bar.

I do this because I run in windowed mode and want to hide these elements to as not distract from my NES gaming goodness.

By the way, thanks for making such an amazing emulator!