### PR TITLE
use virtualGeometry to position window on screen

### DIFF
--- a/src/gui/dlgVsSystem.cpp
+++ b/src/gui/dlgVsSystem.cpp
@@ -128,10 +128,9 @@ void dlgVsSystem::changeEvent(QEvent *event) {
 }
 
 int dlgVsSystem::update_pos(int startY) {
-	int screenNumber = qApp->desktop()->screenNumber(parentWidget());
 	int x = parentWidget()->pos().x() + parentWidget()->frameGeometry().width();
 	int y = parentWidget()->geometry().y() + startY;
-	QRect g = QGuiApplication::screens().at(screenNumber)->geometry();
+	QRect g = QGuiApplication::primaryScreen()->virtualGeometry();
 
 	if ((x + frameGeometry().width() - g.left()) > g.width()) {
 		x = parentWidget()->pos().x() - frameGeometry().width();

--- a/src/gui/mainWindow.cpp
+++ b/src/gui/mainWindow.cpp
@@ -240,18 +240,14 @@ void mainWindow::closeEvent(QCloseEvent *event) {
 
 	shcjoy_stop();
 
-	// in linux non posso spostare tramite le qt una finestra da un monitor
-	// ad un'altro, quindi salvo la posizione solo se sono sul monitor 0;
-	if (qApp->desktop()->screenNumber(this) == 0) {
-		if (cfg->fullscreen == NO_FULLSCR) {
-			cfg->lg.x = geometry().x();
-			cfg->lg.y = geometry().y();
-		}
-		cfg->lg_settings.x = dlgsettings->geom.x();
-		cfg->lg_settings.y = dlgsettings->geom.y();
-		cfg->lg_settings.w = dlgsettings->geom.width();
-		cfg->lg_settings.h = dlgsettings->geom.height();
+	if (cfg->fullscreen == NO_FULLSCR) {
+		cfg->lg.x = geometry().x();
+		cfg->lg.y = geometry().y();
 	}
+	cfg->lg_settings.x = dlgsettings->geom.x();
+	cfg->lg_settings.y = dlgsettings->geom.y();
+	cfg->lg_settings.w = dlgsettings->geom.width();
+	cfg->lg_settings.h = dlgsettings->geom.height();
 
 	settings_save_GUI();
 

--- a/src/gui/qt.cpp
+++ b/src/gui/qt.cpp
@@ -139,8 +139,7 @@ BYTE gui_create(void) {
 	gfx.device_pixel_ratio = qt.screen->devicePixelRatioF();
 
 	{
-		int screenNumber = qApp->desktop()->screenNumber(qt.mwin);
-		QRect geometry = QGuiApplication::screens().at(screenNumber)->geometry();
+		QRect geometry = QGuiApplication::primaryScreen()->virtualGeometry();
 
 		if ((cfg->lg.x == 0) || cfg->lg.x > geometry.width()) {
 			cfg->lg.x = 80;


### PR DESCRIPTION
virtualGeometry gives us the size of a virtual screen that contains all monitors.
This allows a window to be placed on the correct screen in a multi-monitor setup.