### PR TITLE
Fix crash saving/loading states to/from files

### DIFF
--- a/src/core/save_slot.c
+++ b/src/core/save_slot.c
@@ -769,7 +769,11 @@ BYTE save_slot_operation(BYTE mode, BYTE slot, FILE *fp) {
 		}
 	}
 
-	save_slot_mem(mode, slot, screen.rd->data, screen_size(), TRUE)
+    if (slot == SAVE_SLOT_FILE) {
+       save_slot_mem(mode, slot, screen.rd->data, screen_size(), FALSE);
+    } else {
+       save_slot_mem(mode, slot, screen.rd->data, screen_size(), TRUE);
+    }
 
 	return (EXIT_OK);
 }


### PR DESCRIPTION
When the image preview code was introduced the logic to set the Qt tooltip with the preview image wasn't bypassed even though the file state slot doesn't have a GUI element. Trying to set the image preview tooltip was causing a segfault.

This fixes issue #137.