### PR TITLE
Introduce ENABLE_FULLSCREEN_RESFREQ option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ option(ENABLE_OPENGL "Use OpenGL support instead of Direct3D 9 (only for Windows
 option(ENABLE_OPENGL_CG "Enable OpenGL nVidia Cg Toolkit support" OFF)
 option(ENABLE_WIN_STATIC_QT "Use precompiled Qt static library (only for Windows)" OFF)
 option(ENABLE_WIN_STATIC_QT560 "Use precompiled Qt 5.6.3 static library (only for Windows)" OFF)
+option(ENABLE_FULLSCREEN_RESFREQ "Enable Fullscreen resolution and auto frequency" ON)
 
 if (ENABLE_GIT_INFO)
 	find_package(Git)
@@ -84,9 +85,8 @@ if(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD" OR CMAKE_SYSTEM_NAME STREQUAL "OpenBSD")
 endif()
 
 if(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD" OR CMAKE_SYSTEM_NAME STREQUAL "OpenBSD" OR CMAKE_SYSTEM_NAME STREQUAL "Linux")
-	find_package(X11)
-	if(NOT X11_FOUND)
-		message(WARNING "libX11 not found, fullscreen resolution and auto frequency disabled")
+	if(ENABLE_FULLSCREEN_RESFREQ)
+		find_package(X11 REQUIRED)
 	endif()
 	# No alternatives, force selection
 	set(ENABLE_OPENGL ON)
@@ -99,6 +99,8 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
 	if(ENABLE_WIN_STATIC_QT560)
 		set(ENABLE_WIN_STATIC_QT ON)
 	endif()
+	# No alternatives, force selection
+	set(ENABLE_FULLSCREEN_RESFREQ ON)
 else()
 	set(ENABLE_WIN_STATIC_QT OFF)
 	set(ENABLE_WIN_STATIC_QT560 OFF)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -558,9 +558,11 @@ set(gui_srcs
 	>
 
 	$<$<PLATFORM_ID:Windows>:
-		gui/windows/monitor.c
 		gui/windows/os_jstick.c
 		gui/windows/resources.rc
+	>
+	$<$<AND:$<PLATFORM_ID:Windows>,$<BOOL:${ENABLE_FULLSCREEN_RESFREQ}>>:
+		gui/windows/monitor.c
 	>
 
 	$<$<PLATFORM_ID:FreeBSD,OpenBSD>:
@@ -571,7 +573,7 @@ set(gui_srcs
 		gui/linux/os_jstick.c
 	>
 
-	$<$<AND:$<PLATFORM_ID:FreeBSD,OpenBSD,Linux>,$<BOOL:${X11_FOUND}>>:
+	$<$<AND:$<PLATFORM_ID:FreeBSD,OpenBSD,Linux>,$<BOOL:${ENABLE_FULLSCREEN_RESFREQ}>>:
 		gui/linux/monitor.c
 	>
 	)
@@ -589,7 +591,9 @@ set(video_srcs
 	video/filters/scale2x.c
 	video/filters/xBRZ.c
 	video/gfx.c
-	video/gfx_monitor.c
+	$<$<BOOL:${ENABLE_FULLSCREEN_RESFREQ}>:
+		video/gfx_monitor.c
+	>
 	video/gfx_thread.c
 	video/shaders/shaders.c
 	$<IF:$<BOOL:${ENABLE_OPENGL}>,
@@ -713,5 +717,5 @@ target_compile_definitions(punes
 		WITH_D3D9
 	>
 	$<$<BOOL:${ENABLE_OPENGL_CG}>:WITH_OPENGL_CG>
-	$<$<BOOL:${X11_FOUND}>:FULLSCREEN_RESFREQ>
+	$<$<BOOL:${ENABLE_FULLSCREEN_RESFREQ}>:FULLSCREEN_RESFREQ>
 	)


### PR DESCRIPTION
This option enables/disables X11 dependency for Linux/FreeBSD/OpenBSD. Windows does not requires any additional dependencies so it always enabled.