### PR TITLE
Fix dlgLog.cpp on aarch64

### DIFF
--- a/src/gui/dlgLog.cpp
+++ b/src/gui/dlgLog.cpp
@@ -304,11 +304,11 @@ void dlgLog::_lclose(BYTE color, const uTCHAR *utxt, va_list ap) {
 }
 void dlgLog::print(types type, const uTCHAR *utxt, va_list ap) {
 	lopen(type, utxt, ap);
-	lclose(nullptr, nullptr);
+	lclose(nullptr, ap);
 }
 void dlgLog::print_box(types type, const uTCHAR *utxt, va_list ap) {
 	lopen_box(type, utxt, ap);
-	lclose_box(nullptr, nullptr);
+	lclose_box(nullptr, ap);
 }
 void dlgLog::extract(void) {
 	QStringList list;


### PR DESCRIPTION
https://logs.nix.ci/?attempt_id=e3a6c07f-d363-4ce9-ae21-8bd16d1648a8&key=nixos%2Fnixpkgs.209485

It doesn't like `std::nullptr_t`:

```
/build/source/src/gui/dlgLog.cpp: In member function 'void dlgLog::print(dlgLog::types, const uTCHAR*, va_list)': /build/source/src/gui/dlgLog.cpp:307:18: error: cannot convert 'std::nullptr_t' to 'va_list' {aka '__va_list'}
  307 |  lclose(nullptr, nullptr);
      |                  ^~~~~~~
      |                  |
      |                  std::nullptr_t
/build/source/src/gui/dlgLog.cpp:238:49: note:   initializing argument 2 of 'void dlgLog::lclose(const uTCHAR*, va_list)'
  238 | void dlgLog::lclose(const uTCHAR *utxt, va_list ap) {
      |                                         ~~~~~~~~^~
/build/source/src/gui/dlgLog.cpp: In member function 'void dlgLog::print_box(dlgLog::types, const uTCHAR*, va_list)':
/build/source/src/gui/dlgLog.cpp:311:22: error: cannot convert 'std::nullptr_t' to 'va_list' {aka '__va_list'}
  311 |  lclose_box(nullptr, nullptr);
      |                      ^~~~~~~
      |                      |
      |                      std::nullptr_t
/build/source/src/gui/dlgLog.cpp:245:53: note:   initializing argument 2 of 'void dlgLog::lclose_box(const uTCHAR*, va_list)'
  245 | void dlgLog::lclose_box(const uTCHAR *utxt, va_list ap) {
      |                                             ~~~~~~~~^~
```

It does like replacing it with an empty `va_list()`, but x86 in return doesn't like that:

```
error: functional cast to array type 'va_list' {aka '__va_list_tag [1]'}
```

Passing through just the `va_list` from the parameters seems to work.

It only uses the `va_list` if the `uTCHAR*` argument is valid, so it should have the same effect in practice.