### PR TITLE
Implement HLT/KIL Opcodes

### DIFF
--- a/src/core/cpu.c
+++ b/src/core/cpu.c
@@ -565,7 +565,7 @@ static const BYTE table_opcode_cycles[256] = {
 /*    0  1  2  3  4  5  6  7  8  9  A  B  C  D  E  F     */
 };
 
-void cpu_exe_op(BYTE nidx) {
+void cpu_exe_op(BYTE nidx) {	
 	nes[nidx].c.cpu.opcode = FALSE;
 	DMC.tick_type = DMC_NORMAL;
 	nes[nidx].c.cpu.opcode_PC = nes[nidx].c.cpu.PC.w;
@@ -651,6 +651,11 @@ void cpu_exe_op(BYTE nidx) {
 	// salvo i cicli presi dall'istruzione...
 	nes[nidx].c.cpu.base_opcode_cycles = table_opcode_cycles[(BYTE)nes[nidx].c.cpu.opcode];
 	mod_cycles_op(+=, nes[nidx].c.cpu.base_opcode_cycles);
+
+	//Jam the cpu if necessary
+	if (nes[nidx].c.cpu.jammed) {
+		return;
+	}
 
 	// ... e la eseguo
 	switch (nes[nidx].c.cpu.opcode) {
@@ -957,18 +962,20 @@ void cpu_exe_op(BYTE nidx) {
 	case 0xBB: ABX(RD_OP, _CYW(LAS), nes[nidx].c.cpu.YR) break;                                  // LAS $ABS,Y
 	case 0x9B: ABX(WR_OP, XAS, nes[nidx].c.cpu.YR) break;                                        // XAS $ABS,Y
 
-	case 0x02: // JAM
-	case 0x12: // JAM
-	case 0x22: // JAM
-	case 0x32: // JAM
-	case 0x42: // JAM
-	case 0x52: // JAM
-	case 0x62: // JAM
-	case 0x72: // JAM
-	case 0x92: // JAM
-	case 0xB2: // JAM
-	case 0xD2: // JAM
-	case 0xF2: // JAM
+	//KIL/HLT instructions. Set the cpu to be jammed
+	case 0x02: nes[nidx].c.cpu.jammed = 1; break;
+	case 0x12: nes[nidx].c.cpu.jammed = 1; break;
+	case 0x22: nes[nidx].c.cpu.jammed = 1; break;
+	case 0x32: nes[nidx].c.cpu.jammed = 1; break;
+	case 0x42: nes[nidx].c.cpu.jammed = 1; break;
+	case 0x52: nes[nidx].c.cpu.jammed = 1; break;
+	case 0x62: nes[nidx].c.cpu.jammed = 1; break;
+	case 0x72: nes[nidx].c.cpu.jammed = 1; break;
+	case 0x92: nes[nidx].c.cpu.jammed = 1; break;
+	case 0xB2: nes[nidx].c.cpu.jammed = 1; break;
+	case 0xD2: nes[nidx].c.cpu.jammed = 1; break;
+	case 0xF2: nes[nidx].c.cpu.jammed = 1; break;
+
 	default:
 		if (!info.no_rom && !info.first_illegal_opcode) {
 			log_warning(uL("cpu;alert PC = 0x%04X, CODEOP = 0x%02X"), (nes[nidx].c.cpu.PC.w - 1), nes[nidx].c.cpu.opcode);
@@ -1061,6 +1068,7 @@ void cpu_turn_on(BYTE nidx) {
 		nes[nidx].c.cpu.opcode_cycle = 0;
 		nes[nidx].c.cpu.double_wr = 0;
 		nes[nidx].c.cpu.double_rd = 0;
+		nes[nidx].c.cpu.jammed = 0;
 	}
 	memset(&nes[nidx].c.nmi, 0x00, sizeof(_nmi));
 	memset(&nes[nidx].c.irq, 0x00, sizeof(_irq));

--- a/src/core/cpu.c
+++ b/src/core/cpu.c
@@ -565,7 +565,7 @@ static const BYTE table_opcode_cycles[256] = {
 /*    0  1  2  3  4  5  6  7  8  9  A  B  C  D  E  F     */
 };
 
-void cpu_exe_op(BYTE nidx) {	
+void cpu_exe_op(BYTE nidx) {
 	nes[nidx].c.cpu.opcode = FALSE;
 	DMC.tick_type = DMC_NORMAL;
 	nes[nidx].c.cpu.opcode_PC = nes[nidx].c.cpu.PC.w;

--- a/src/core/cpu.c
+++ b/src/core/cpu.c
@@ -963,25 +963,25 @@ void cpu_exe_op(BYTE nidx) {
 	case 0x9B: ABX(WR_OP, XAS, nes[nidx].c.cpu.YR) break;                                        // XAS $ABS,Y
 
 	//KIL/HLT instructions. Set the cpu to be jammed
-	case 0x02: nes[nidx].c.cpu.jammed = 1; break;
-	case 0x12: nes[nidx].c.cpu.jammed = 1; break;
-	case 0x22: nes[nidx].c.cpu.jammed = 1; break;
-	case 0x32: nes[nidx].c.cpu.jammed = 1; break;
-	case 0x42: nes[nidx].c.cpu.jammed = 1; break;
-	case 0x52: nes[nidx].c.cpu.jammed = 1; break;
-	case 0x62: nes[nidx].c.cpu.jammed = 1; break;
-	case 0x72: nes[nidx].c.cpu.jammed = 1; break;
-	case 0x92: nes[nidx].c.cpu.jammed = 1; break;
-	case 0xB2: nes[nidx].c.cpu.jammed = 1; break;
-	case 0xD2: nes[nidx].c.cpu.jammed = 1; break;
-	case 0xF2: nes[nidx].c.cpu.jammed = 1; break;
-
+	case 0x02:
+	case 0x12:
+	case 0x22:
+	case 0x32:
+	case 0x42:
+	case 0x52:
+	case 0x62:
+	case 0x72:
+	case 0x92:
+	case 0xB2:
+	case 0xD2:
+	case 0xF2:
 	default:
 		if (!info.no_rom && !info.first_illegal_opcode) {
 			log_warning(uL("cpu;alert PC = 0x%04X, CODEOP = 0x%02X"), (nes[nidx].c.cpu.PC.w - 1), nes[nidx].c.cpu.opcode);
 			gui_overlay_info_append_msg_precompiled(4, NULL);
 			info.first_illegal_opcode = TRUE;
 		}
+		nes[nidx].c.cpu.jammed = 1;
 		nes[nidx].c.cpu.cycles = 0;
 		break;
 	case OP_NMI: IMP(RD_OP, NMI) break;                                                          // NMI

--- a/src/core/cpu.h
+++ b/src/core/cpu.h
@@ -88,6 +88,8 @@ typedef struct _cpu {
 	WORD base_opcode_cycles;
 	// buffer di lettura
 	BYTE openbus;
+	//Set to true by KIL/HLT instruction
+	BYTE jammed;
 } _cpu;
 typedef struct _irq {
 	BYTE high;


### PR DESCRIPTION
There is a speedrun category in Super Mario Bros. 3 where you do a glitch involving memory corruption. This memory corruption sometimes causes illegal opcodes to be executed and HLT/KIL opcodes will crash the game on original hardware. The mods therefore decided to ban puNES and Mesen for the category. This PR implements the opcodes so that the cpu will freeze like it should if HLT/KIL opcodes are encountered.