### PR TITLE
Fix compatibility with Qt 6.7.1

### DIFF
--- a/src/gui/dlgStdPad.hpp
+++ b/src/gui/dlgStdPad.hpp
@@ -47,6 +47,8 @@ typedef struct _joy_list {
 extern _joy_list joy_list;
 
 class pixmapButton: public QPushButton {
+	Q_OBJECT
+
 	private:
 		QPixmap pixmap;
 


### PR DESCRIPTION
Upstream [QTBUG-105023](https://bugreports.qt.io/browse/QTBUG-105023) [fix](https://github.com/qt/qtbase/commit/9c1752d7b19b67bd7cd2f8229b80a13aeb61becd) made it mandatory that arguments to QObject::findChild[ren] calls must be `Q_OBJECT`s.

Fixes FTBFS with Qt 6.7.1:
```
[ 89%] Building CXX object src/CMakeFiles/punes.dir/gui/dlgStdPad.cpp.o
In file included from /nix/store/ikqvl8jq0d7vlp25d9zlbh44m4hljahc-qtbase-6.7.1/include/QtCore/qiodevice.h:10,
                 from /nix/store/ikqvl8jq0d7vlp25d9zlbh44m4hljahc-qtbase-6.7.1/include/QtCore/qbuffer.h:7,
                 from /nix/store/ikqvl8jq0d7vlp25d9zlbh44m4hljahc-qtbase-6.7.1/include/QtCore/QBuffer:1,
                 from /build/source/src/gui/dlgStdPad.cpp:19:
/nix/store/ikqvl8jq0d7vlp25d9zlbh44m4hljahc-qtbase-6.7.1/include/QtCore/qobject.h: In instantiation of 'T QObject::findChild(QAnyStringView, Qt::FindChildOptions) const [with T = pixmapButton*; Qt::FindChildOptions = QFlags<Qt::FindChildOption>]':
/build/source/src/gui/dlgStdPad.cpp:99:35:   required from here
/nix/store/ikqvl8jq0d7vlp25d9zlbh44m4hljahc-qtbase-6.7.1/include/QtCore/qobject.h:151:62: error: static assertion failed: No Q_OBJECT in the class passed to QObject::findChild
  151 |         static_assert(QtPrivate::HasQ_OBJECT_Macro<ObjType>::Value,
      |                                                              ^~~~~
/nix/store/ikqvl8jq0d7vlp25d9zlbh44m4hljahc-qtbase-6.7.1/include/QtCore/qobject.h:151:62: note: 'QtPrivate::HasQ_OBJECT_Macro<pixmapButton>::Value' evaluates to false
make[2]: *** [src/CMakeFiles/punes.dir/build.make:7505: src/CMakeFiles/punes.dir/gui/dlgStdPad.cpp.o] Error 1
```