### PR TITLE
Use the udev "uniq" attribute when generating the device GUID

### DIFF
--- a/src/core/jstick.c
+++ b/src/core/jstick.c
@@ -155,15 +155,13 @@ void js_guid_create(_js_device *jdev) {
 		(*(word + 6)) = jdev->usb.version;
 		(*(word + 7)) = jdev->usb.version - 400;
 #if defined (__linux__)
-		if (ustrlen(jdev->uniq)) {
-			BYTE *byte = (BYTE *)&word[2];
-			int idx = 0;
+		BYTE *byte = (BYTE *)&word[2];
+		int idx = 0;
 
-			for (const char *s = jdev->uniq; *s; ++s) {
-				byte[idx++] ^= *s;
-				if (idx > 11) {
-					idx = 0;
-				}
+		for (const char *s = jdev->uniq; *s; ++s) {
+			byte[idx++] ^= *s;
+			if (idx > 11) {
+				idx = 0;
 			}
 		}
 #endif

--- a/src/core/jstick.c
+++ b/src/core/jstick.c
@@ -154,6 +154,15 @@ void js_guid_create(_js_device *jdev) {
 		(*(word + 5)) = jdev->usb.product_id - 300;
 		(*(word + 6)) = jdev->usb.version;
 		(*(word + 7)) = jdev->usb.version - 400;
+
+		BYTE *byte = (BYTE *)&word[2];
+		int idx = 0;
+		for (const char *s = jdev->uniq; *s; ++s) {
+			byte[idx++] ^= *s;
+			if (idx > 11) {
+				idx = 0;
+			}
+		}
 	} else {
 		word += 2;
 		memcpy((char *)word, (char *)jdev->desc, sizeof(jdev->guid.data) - 4);

--- a/src/core/jstick.c
+++ b/src/core/jstick.c
@@ -154,7 +154,7 @@ void js_guid_create(_js_device *jdev) {
 		(*(word + 5)) = jdev->usb.product_id - 300;
 		(*(word + 6)) = jdev->usb.version;
 		(*(word + 7)) = jdev->usb.version - 400;
-#if defined (_linux__)
+#if defined (__linux__)
 		if (ustrlen(jdev->uniq)) {
 			BYTE *byte = (BYTE *)&word[2];
 			int idx = 0;

--- a/src/core/jstick.c
+++ b/src/core/jstick.c
@@ -154,15 +154,19 @@ void js_guid_create(_js_device *jdev) {
 		(*(word + 5)) = jdev->usb.product_id - 300;
 		(*(word + 6)) = jdev->usb.version;
 		(*(word + 7)) = jdev->usb.version - 400;
+#if defined (_linux__)
+		if (ustrlen(jdev->uniq)) {
+			BYTE *byte = (BYTE *)&word[2];
+			int idx = 0;
 
-		BYTE *byte = (BYTE *)&word[2];
-		int idx = 0;
-		for (const char *s = jdev->uniq; *s; ++s) {
-			byte[idx++] ^= *s;
-			if (idx > 11) {
-				idx = 0;
+			for (const char *s = jdev->uniq; *s; ++s) {
+				byte[idx++] ^= *s;
+				if (idx > 11) {
+					idx = 0;
+				}
 			}
 		}
+#endif
 	} else {
 		word += 2;
 		memcpy((char *)word, (char *)jdev->desc, sizeof(jdev->guid.data) - 4);

--- a/src/core/jstick.h
+++ b/src/core/jstick.h
@@ -165,6 +165,7 @@ typedef struct _js_device {
 	// comuni
 	enum _js_gamepad_type type;
 	uTCHAR desc[128];
+	uTCHAR uniq[64];
 	_js_info info;
 	_js_data data;
 	_input_guid guid;

--- a/src/core/jstick.h
+++ b/src/core/jstick.h
@@ -162,10 +162,12 @@ typedef struct _js_device {
 	} report;
 #endif
 #endif
+#if defined (__linux__)
+	uTCHAR uniq[64];
+#endif
 	// comuni
 	enum _js_gamepad_type type;
 	uTCHAR desc[128];
-	uTCHAR uniq[64];
 	_js_info info;
 	_js_data data;
 	_input_guid guid;

--- a/src/gui/linux/os_jstick.c
+++ b/src/gui/linux/os_jstick.c
@@ -73,12 +73,15 @@ void js_os_jdev_open(_js_device *jdev, void *arg) {
 			const char *vid = udev_device_get_sysattr_value(udevd, "id/vendor");
 			const char *ver = udev_device_get_sysattr_value(udevd, "id/version");
 			const char *name = udev_device_get_sysattr_value(udevd, "name");
+			const char *uniq = udev_device_get_sysattr_value(udevd, "uniq");
 
 			jdev->usb.bustype = strtoul(btype, NULL, 16);
 			jdev->usb.vendor_id = strtoul(vid, NULL, 16);
 			jdev->usb.product_id = strtoul(pid, NULL, 16);
 			jdev->usb.version = strtoul(ver, NULL, 16);
+
 			ustrncpy(jdev->desc, name, usizeof(jdev->desc) - 1);
+			ustrncpy(jdev->uniq, uniq, usizeof(jdev->uniq) - 1);
 		} else {
 			return;
 		}


### PR DESCRIPTION
I have two PS3 joysticks; I can use one without problems. But when I connect the second, I can't set up the second pad because puNES can't understand which one to pick due to identical GUIDs.

Adding a simple index to the GUID generator resolves the problem.